### PR TITLE
Added unistd.h to allow ubuntu/debian build and update address tables to make easier to work with on large address tables

### DIFF
--- a/src/libfwbuilder/src/fwbuilder/ThreadTools.h
+++ b/src/libfwbuilder/src/fwbuilder/ThreadTools.h
@@ -31,7 +31,7 @@
 
 #include <time.h> //for time_t definition
 #include <pthread.h>
-
+#include <unistd.h>
 #include <string>
 #include <queue>
 

--- a/src/res/configlets/linux24/run_time_address_tables
+++ b/src/res/configlets/linux24/run_time_address_tables
@@ -56,6 +56,9 @@ reload_address_table() {
     $IPSET -N tmp_fwb_set:ip  iphash
     $IPSET -N tmp_fwb_set:net nethash
 
+    DATAFILE_SIZE=`wc -l $data_file|cut -d" " -f 1`
+    echo "Processing $DATAFILE_SIZE items in file: $data_file"
+
     grep -Ev '^#|^;|^\s*$' $data_file | while read L ; do
         set $L
         addr=$1

--- a/src/res/configlets/linux24/script_skeleton
+++ b/src/res/configlets/linux24/script_skeleton
@@ -89,7 +89,6 @@ case "$cmd" in
         check_run_time_address_table_files
         {{if using_ipset}}
         check_module_ipset
-        load_run_time_address_table_files
         {{endif}}
         load_modules "{{$load_modules_with_nat}} {{$load_modules_with_ipv6}}"
         configure_interfaces
@@ -99,6 +98,9 @@ case "$cmd" in
         {{if prolog_after_flush}} prolog_commands {{endif}}
         script_body
         ip_forward
+        {{if using_ipset}}
+        load_run_time_address_table_files
+        {{endif}}
         epilog_commands
         RETVAL=$?
         ;;


### PR DESCRIPTION
Added unistd.h to src/libfwbuilder/src/fwbuilder/ThreadTools.h to enable ssize_t from debian bug 67439 https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=674349

Updated the iptables ipset address table.  In the run_time_address_table I added the output of which data_file was being worked on and how many lines in the file.

For the script_skeleton I moved the loading of the address table to after the filter rules are loaded. This is because with a large address table (say blocking russia or china) it can take a long time to load and the devices filters should be loaded as soon as possible and not left open while loading table data.

Signed-off-by: David M. Zendzian @ <dmz@zzservers.com>