### PR TITLE
iptables -m conntrack and -w option support

### DIFF
--- a/src/iptlib/CompilerDriver_ipt_run.cpp
+++ b/src/iptlib/CompilerDriver_ipt_run.cpp
@@ -678,7 +678,7 @@ QString CompilerDriver_ipt::run(const std::string &cluster_id,
         script_buffer = "";
 
         Configlet block_action(fw, "linux24", "block_action");
-        if (XMLTools::version_compare(version, "1.4.20") >= 0)
+        if (XMLTools::version_compare(fw_version, "1.4.20") >= 0)
             block_action.setVariable("opt_wait", "-w");
         else
             block_action.setVariable("opt_wait", "");
@@ -707,7 +707,7 @@ QString CompilerDriver_ipt::run(const std::string &cluster_id,
         stop_action.setVariable("have_ipv4", have_ipv4);
         stop_action.setVariable("have_ipv6", have_ipv6);
 
-        if (XMLTools::version_compare(version, "1.4.20") >= 0)
+        if (XMLTools::version_compare(fw_version, "1.4.20") >= 0)
             stop_action.setVariable("opt_wait", "-w");
         else
             stop_action.setVariable("opt_wait", "");

--- a/src/iptlib/CompilerDriver_ipt_run.cpp
+++ b/src/iptlib/CompilerDriver_ipt_run.cpp
@@ -678,6 +678,11 @@ QString CompilerDriver_ipt::run(const std::string &cluster_id,
         script_buffer = "";
 
         Configlet block_action(fw, "linux24", "block_action");
+        if (XMLTools::version_compare(version, "1.4.20") >= 0)
+            block_action.setVariable("opt_wait", "-w");
+        else
+            block_action.setVariable("opt_wait", "");
+
         block_action.collapseEmptyStrings(true);
 
         // the name of the option is historical (including the typo)
@@ -701,6 +706,11 @@ QString CompilerDriver_ipt::run(const std::string &cluster_id,
         stop_action.collapseEmptyStrings(true);
         stop_action.setVariable("have_ipv4", have_ipv4);
         stop_action.setVariable("have_ipv6", have_ipv6);
+
+        if (XMLTools::version_compare(version, "1.4.20") >= 0)
+            stop_action.setVariable("opt_wait", "-w");
+        else
+            stop_action.setVariable("opt_wait", "");
 
         script_skeleton.setVariable("stop_action", stop_action.expand());
 

--- a/src/iptlib/NATCompiler_PrintRule.cpp
+++ b/src/iptlib/NATCompiler_PrintRule.cpp
@@ -124,9 +124,9 @@ string NATCompiler_ipt::PrintRule::_createChain(const string &chain)
         string opt_wait;
 
         if (XMLTools::version_compare(version, "1.4.20")>=0)
-            string opt_wait = "-w ";
+            opt_wait = "-w ";
         else
-            string opt_wait = "";
+            opt_wait = "";
 
         string ipt_cmd = (ipt_comp->ipv6) ? "$IP6TABLES " : "$IPTABLES ";
 	res << ipt_cmd << opt_wait << "-t nat -N " << chain << endl;
@@ -143,9 +143,9 @@ string NATCompiler_ipt::PrintRule::_startRuleLine()
     string opt_wait;
 
     if (XMLTools::version_compare(version, "1.4.20")>=0)
-        string opt_wait = "-w ";
+        opt_wait = "-w ";
     else
-        string opt_wait = ""; 
+        opt_wait = ""; 
 
     return res + opt_wait + string("-t nat -A ");
 }

--- a/src/iptlib/NATCompiler_PrintRule.cpp
+++ b/src/iptlib/NATCompiler_PrintRule.cpp
@@ -121,8 +121,15 @@ string NATCompiler_ipt::PrintRule::_createChain(const string &chain)
 
     if ( ipt_comp->minus_n_commands->count(chain)==0 )
     {
+        string opt_wait;
+
+        if (XMLTools::version_compare(version, "1.4.20")>=0)
+            string opt_wait = "-w ";
+        else
+            string opt_wait = "";
+
         string ipt_cmd = (ipt_comp->ipv6) ? "$IP6TABLES " : "$IPTABLES ";
-	res << ipt_cmd << "-t nat -N " << chain << endl;
+	res << ipt_cmd << opt_wait << "-t nat -N " << chain << endl;
 	(*(ipt_comp->minus_n_commands))[chain] = true;
     }
     return res.str();
@@ -132,7 +139,15 @@ string NATCompiler_ipt::PrintRule::_startRuleLine()
 {            
     NATCompiler_ipt *ipt_comp = dynamic_cast<NATCompiler_ipt*>(compiler);
     string res = (ipt_comp->ipv6) ? "$IP6TABLES " : "$IPTABLES ";
-    return res + string("-t nat -A ");
+
+    string opt_wait;
+
+    if (XMLTools::version_compare(version, "1.4.20")>=0)
+        string opt_wait = "-w ";
+    else
+        string opt_wait = ""; 
+
+    return res + opt_wait + string("-t nat -A ");
 }
 
 string NATCompiler_ipt::PrintRule::_endRuleLine()

--- a/src/iptlib/OSConfigurator_linux24.cpp
+++ b/src/iptlib/OSConfigurator_linux24.cpp
@@ -359,6 +359,11 @@ string OSConfigurator_linux24::printShellFunctions(bool have_ipv6)
      * default policy
      */
     Configlet reset_iptables(fw, "linux24", "reset_iptables");
+    if (XMLTools::version_compare(version, "1.4.20") >= 0)
+        reset_iptables.setVariable("opt_wait", "-w");
+    else
+        reset_iptables.setVariable("opt_wait", "");
+
     output.push_back(reset_iptables.expand());
 
     Configlet addr_conf(fw, "linux24", "update_addresses");

--- a/src/iptlib/OSConfigurator_linux24.cpp
+++ b/src/iptlib/OSConfigurator_linux24.cpp
@@ -309,6 +309,7 @@ string OSConfigurator_linux24::printShellFunctions(bool have_ipv6)
     QStringList output;
     FWOptions* options = fw->getOptionsObject();
 
+    string version = fw->getStr("version");
     // string host_os = fw->getStr("host_OS");
     // string os_family = Resources::os_res[host_os]->
     //     getResourceStr("/FWBuilderResources/Target/family");

--- a/src/iptlib/PolicyCompiler_PrintRule.cpp
+++ b/src/iptlib/PolicyCompiler_PrintRule.cpp
@@ -1632,11 +1632,17 @@ string PolicyCompiler_ipt::PrintRule::PolicyRuleToString(PolicyRule *rule)
 */
     if (!ruleopt->getBool("stateless") || rule->getBool("force_state_check") )
     {
+        string state_module_option;
         /*
          * But not, when the line already contains a state matching
          */
-        if (command_line.str().find("-m state --state", 0) == string::npos)
-            command_line << " -m state --state NEW ";
+        if (XMLTools::version_compare(version, "1.4.4")>=0)
+            state_module_option = "-m conntrack --ctstate";
+        else
+            state_module_option = "-m state --state";
+
+        if (command_line.str().find(state_module_option, 0) == string::npos)
+            command_line << " " << state_module_option << " NEW ";
     }
 
     command_line << _printTimeInterval(rule);

--- a/src/iptlib/PolicyCompiler_PrintRule.cpp
+++ b/src/iptlib/PolicyCompiler_PrintRule.cpp
@@ -139,9 +139,9 @@ string PolicyCompiler_ipt::PrintRule::_createChain(const string &chain)
         string opt_wait;
 
         if (XMLTools::version_compare(version, "1.4.20")>=0)
-            string opt_wait = "-w ";
+            opt_wait = "-w ";
         else
-            string opt_wait = "";
+            opt_wait = "";
 
 	res = string((ipt_comp->ipv6) ? "$IP6TABLES -N " : "$IPTABLES -N ") +
             opt_wait + chain;
@@ -159,9 +159,9 @@ string PolicyCompiler_ipt::PrintRule::_startRuleLine()
     string opt_wait;
 
     if (XMLTools::version_compare(version, "1.4.20")>=0)
-        string opt_wait = "-w ";
+        opt_wait = "-w ";
     else
-        string opt_wait = "";
+        opt_wait = "";
 
     if (ipt_comp->my_table != "filter") res += opt_wait + "-t " + ipt_comp->my_table + " ";
 

--- a/src/iptlib/PolicyCompiler_PrintRule.cpp
+++ b/src/iptlib/PolicyCompiler_PrintRule.cpp
@@ -136,8 +136,15 @@ string PolicyCompiler_ipt::PrintRule::_createChain(const string &chain)
 
     if ( ipt_comp->minus_n_commands->count(chain)==0 )
     {
+        string opt_wait;
+
+        if (XMLTools::version_compare(version, "1.4.20")>=0)
+            string opt_wait = "-w ";
+        else
+            string opt_wait = "";
+
 	res = string((ipt_comp->ipv6) ? "$IP6TABLES -N " : "$IPTABLES -N ") +
-            chain;
+            opt_wait + chain;
         if (ipt_comp->my_table != "filter") res += " -t " + ipt_comp->my_table;
         res += "\n";
 	(*(ipt_comp->minus_n_commands))[chain] = true;
@@ -149,8 +156,14 @@ string PolicyCompiler_ipt::PrintRule::_startRuleLine()
 {            
     PolicyCompiler_ipt *ipt_comp = dynamic_cast<PolicyCompiler_ipt*>(compiler);
     string res = (ipt_comp->ipv6) ? "$IP6TABLES " : "$IPTABLES ";
+    string opt_wait;
 
-    if (ipt_comp->my_table != "filter") res += "-t " + ipt_comp->my_table + " ";
+    if (XMLTools::version_compare(version, "1.4.20")>=0)
+        string opt_wait = "-w ";
+    else
+        string opt_wait = "";
+
+    if (ipt_comp->my_table != "filter") res += opt_wait + "-t " + ipt_comp->my_table + " ";
 
     res += "-A ";
     return res;

--- a/src/iptlib/PolicyCompiler_PrintRule.cpp
+++ b/src/iptlib/PolicyCompiler_PrintRule.cpp
@@ -1637,12 +1637,12 @@ string PolicyCompiler_ipt::PrintRule::PolicyRuleToString(PolicyRule *rule)
          * But not, when the line already contains a state matching
          */
         if (XMLTools::version_compare(version, "1.4.4")>=0)
-            state_module_option = "-m conntrack --ctstate";
+            state_module_option = "conntrack --ctstate";
         else
-            state_module_option = "-m state --state";
+            state_module_option = "state --state";
 
-        if (command_line.str().find(state_module_option, 0) == string::npos)
-            command_line << " " << state_module_option << " NEW ";
+        if (command_line.str().find("-m " + state_module_option, 0) == string::npos)
+            command_line << " -m " << state_module_option << " NEW ";
     }
 
     command_line << _printTimeInterval(rule);
@@ -1714,6 +1714,7 @@ string PolicyCompiler_ipt::PrintRule::_printOptionalGlobalRules()
     PolicyCompiler_ipt *ipt_comp = dynamic_cast<PolicyCompiler_ipt*>(compiler);
     ostringstream res;
     bool isIPv6 = ipt_comp->ipv6;
+    string state_module_option;
 
     string s = compiler->getCachedFwOpt()->getStr("linux24_ip_forward");
     bool ipforward= (s.empty() || s=="1" || s=="On" || s=="on");
@@ -1734,6 +1735,13 @@ string PolicyCompiler_ipt::PrintRule::_printOptionalGlobalRules()
     configlet.setVariable("accept_established", 
                           compiler->getCachedFwOpt()->getBool("accept_established") &&
                           ipt_comp->my_table=="filter");
+
+    if (XMLTools::version_compare(version, "1.4.4")>=0)
+        state_module_option = "conntrack --ctstate";
+    else
+        state_module_option = "state --state";
+
+    configlet.setVariable("state_module_option", state_module_option.c_str());
 
     list<FWObject*> ll = compiler->fw->getByTypeDeep(Interface::TYPENAME);
     for (FWObject::iterator i=ll.begin(); i!=ll.end(); i++)

--- a/src/iptlib/PolicyCompiler_PrintRule.cpp
+++ b/src/iptlib/PolicyCompiler_PrintRule.cpp
@@ -143,8 +143,8 @@ string PolicyCompiler_ipt::PrintRule::_createChain(const string &chain)
         else
             opt_wait = "";
 
-	res = string((ipt_comp->ipv6) ? "$IP6TABLES -N " : "$IPTABLES -N ") +
-            opt_wait + chain;
+	res = string((ipt_comp->ipv6) ? "$IP6TABLES " : "$IPTABLES ") +
+            opt_wait + "-N " + chain;
         if (ipt_comp->my_table != "filter") res += " -t " + ipt_comp->my_table;
         res += "\n";
 	(*(ipt_comp->minus_n_commands))[chain] = true;
@@ -163,7 +163,9 @@ string PolicyCompiler_ipt::PrintRule::_startRuleLine()
     else
         opt_wait = "";
 
-    if (ipt_comp->my_table != "filter") res += opt_wait + "-t " + ipt_comp->my_table + " ";
+    res += opt_wait;
+
+    if (ipt_comp->my_table != "filter") res += "-t " + ipt_comp->my_table + " ";
 
     res += "-A ";
     return res;

--- a/src/libgui/platforms.cpp
+++ b/src/libgui/platforms.cpp
@@ -433,6 +433,7 @@ void getVersionsForPlatform(const QString &platform, std::list<QStringPair> &res
         res.push_back(QStringPair("1.4.1.1", QObject::tr("1.4.1.1 or later")));
         res.push_back(QStringPair("1.4.3", QObject::tr("1.4.3")));
         res.push_back(QStringPair("1.4.4", QObject::tr("1.4.4 or later")));
+        res.push_back(QStringPair("1.4.20", QObject::tr("1.4.20 or later")));
     } else
     {
         // we list supported versions for the following platforms in

--- a/src/res/configlets/linux24/automatic_rules
+++ b/src/res/configlets/linux24/automatic_rules
@@ -50,9 +50,9 @@
 
 {{if accept_established}}
 # accept established sessions
-{{$begin_rule}} INPUT   -m state --state ESTABLISHED,RELATED -j ACCEPT {{$end_rule}}
-{{$begin_rule}} OUTPUT  -m state --state ESTABLISHED,RELATED -j ACCEPT {{$end_rule}}
-{{$begin_rule}} FORWARD -m state --state ESTABLISHED,RELATED -j ACCEPT {{$end_rule}}
+{{$begin_rule}} INPUT   -m {{$state_module_option}} ESTABLISHED,RELATED -j ACCEPT {{$end_rule}}
+{{$begin_rule}} OUTPUT  -m {{$state_module_option}} ESTABLISHED,RELATED -j ACCEPT {{$end_rule}}
+{{$begin_rule}} FORWARD -m {{$state_module_option}} ESTABLISHED,RELATED -j ACCEPT {{$end_rule}}
 {{endif}}
 
 
@@ -67,16 +67,16 @@
 
 {{if mgmt_access}}
 # backup ssh access
-{{$begin_rule}} INPUT  -p tcp -m tcp  -s {{$ssh_management_address}}  --dport 22  -m state --state NEW,ESTABLISHED -j  ACCEPT {{$end_rule}}
-{{$begin_rule}} OUTPUT  -p tcp -m tcp  -d {{$ssh_management_address}}  --sport 22  -m state --state ESTABLISHED,RELATED -j ACCEPT {{$end_rule}}
+{{$begin_rule}} INPUT  -p tcp -m tcp  -s {{$ssh_management_address}}  --dport 22  -m {{$state_module_option}} NEW,ESTABLISHED -j  ACCEPT {{$end_rule}}
+{{$begin_rule}} OUTPUT  -p tcp -m tcp  -d {{$ssh_management_address}}  --sport 22  -m {{$state_module_option}} ESTABLISHED,RELATED -j ACCEPT {{$end_rule}}
 {{endif}}
 
 {{if drop_new_tcp_with_no_syn}}
 # drop TCP sessions opened prior firewall restart
-{{$begin_rule}} INPUT   -p tcp -m tcp ! --tcp-flags SYN,RST,ACK SYN -m state --state NEW -j DROP {{$end_rule}}
-{{$begin_rule}} OUTPUT  -p tcp -m tcp ! --tcp-flags SYN,RST,ACK SYN -m state --state NEW -j DROP {{$end_rule}}
+{{$begin_rule}} INPUT   -p tcp -m tcp ! --tcp-flags SYN,RST,ACK SYN -m {{$state_module_option}} NEW -j DROP {{$end_rule}}
+{{$begin_rule}} OUTPUT  -p tcp -m tcp ! --tcp-flags SYN,RST,ACK SYN -m {{$state_module_option}} NEW -j DROP {{$end_rule}}
 {{if ipforw}}
-{{$begin_rule}} FORWARD -p tcp -m tcp ! --tcp-flags SYN,RST,ACK SYN -m state --state NEW -j DROP {{$end_rule}}
+{{$begin_rule}} FORWARD -p tcp -m tcp ! --tcp-flags SYN,RST,ACK SYN -m {{$state_module_option}} NEW -j DROP {{$end_rule}}
 {{endif}}
 {{endif}}
 
@@ -100,20 +100,20 @@
 
 {{if drop_invalid}}
 # drop packets that do not match any valid state 
-{{$begin_rule}} OUTPUT   -m state --state INVALID  -j DROP {{$end_rule}}
-{{$begin_rule}} INPUT    -m state --state INVALID  -j DROP {{$end_rule}}
+{{$begin_rule}} OUTPUT   -m {{$state_module_option}} INVALID  -j DROP {{$end_rule}}
+{{$begin_rule}} INPUT    -m {{$state_module_option}} INVALID  -j DROP {{$end_rule}}
 {{if ipforw}}
-{{$begin_rule}} FORWARD  -m state --state INVALID  -j DROP {{$end_rule}}
+{{$begin_rule}} FORWARD  -m {{$state_module_option}} INVALID  -j DROP {{$end_rule}}
 {{endif}}
 {{endif}}
 
 {{if drop_invalid_and_log}}
 # drop packets that do not match any valid state and log them
 {{$create_drop_invalid_chain}}
-{{$begin_rule}} OUTPUT   -m state --state INVALID  -j drop_invalid {{$end_rule}}
-{{$begin_rule}} INPUT    -m state --state INVALID  -j drop_invalid {{$end_rule}}
+{{$begin_rule}} OUTPUT   -m {{$state_module_option}} INVALID  -j drop_invalid {{$end_rule}}
+{{$begin_rule}} INPUT    -m {{$state_module_option}} INVALID  -j drop_invalid {{$end_rule}}
 {{if ipforw}}
-{{$begin_rule}} FORWARD  -m state --state INVALID  -j drop_invalid {{$end_rule}}
+{{$begin_rule}} FORWARD  -m {{$state_module_option}} INVALID  -j drop_invalid {{$end_rule}}
 {{endif}}
 
 {{if use_ulog}}

--- a/src/res/configlets/linux24/block_action
+++ b/src/res/configlets/linux24/block_action
@@ -30,8 +30,8 @@ block_action() {
 
 {{if mgmt_access}}
     # backup ssh access
-    $IPTABLES -A INPUT  -p tcp -m tcp  -s {{$ssh_management_address}}  --dport 22  -m state --state NEW,ESTABLISHED -j  ACCEPT
-    $IPTABLES -A OUTPUT  -p tcp -m tcp  -d {{$ssh_management_address}}  --sport 22  -m state --state ESTABLISHED,RELATED -j ACCEPT
+    $IPTABLES {{$opt_wait}} -A INPUT  -p tcp -m tcp  -s {{$ssh_management_address}}  --dport 22  -m state --state NEW,ESTABLISHED -j  ACCEPT
+    $IPTABLES {{$opt_wait}} -A OUTPUT  -p tcp -m tcp  -d {{$ssh_management_address}}  --sport 22  -m state --state ESTABLISHED,RELATED -j ACCEPT
 {{endif}}
 }
 

--- a/src/res/configlets/linux24/reset_iptables
+++ b/src/res/configlets/linux24/reset_iptables
@@ -12,32 +12,32 @@
 ## {{if var}} is conditional operator.
 ##
 reset_iptables_v4() {
-  $IPTABLES -P OUTPUT  DROP
-  $IPTABLES -P INPUT   DROP
-  $IPTABLES -P FORWARD DROP
+  $IPTABLES {{$opt_wait}} -P OUTPUT  DROP
+  $IPTABLES {{$opt_wait}} -P INPUT   DROP
+  $IPTABLES {{$opt_wait}} -P FORWARD DROP
 
 cat /proc/net/ip_tables_names | while read table; do
-  $IPTABLES -t $table -L -n | while read c chain rest; do
+  $IPTABLES {{$opt_wait}} -t $table -L -n | while read c chain rest; do
       if test "X$c" = "XChain" ; then
-        $IPTABLES -t $table -F $chain
+        $IPTABLES {{$opt_wait}} -t $table -F $chain
       fi
   done
-  $IPTABLES -t $table -X
+  $IPTABLES {{$opt_wait}} -t $table -X
 done
 }
 
 reset_iptables_v6() {
-  $IP6TABLES -P OUTPUT  DROP
-  $IP6TABLES -P INPUT   DROP
-  $IP6TABLES -P FORWARD DROP
+  $IP6TABLES {{$opt_wait}} -P OUTPUT  DROP
+  $IP6TABLES {{$opt_wait}} -P INPUT   DROP
+  $IP6TABLES {{$opt_wait}} -P FORWARD DROP
 
 cat /proc/net/ip6_tables_names | while read table; do
-  $IP6TABLES -t $table -L -n | while read c chain rest; do
+  $IP6TABLES {{$opt_wait}} -t $table -L -n | while read c chain rest; do
       if test "X$c" = "XChain" ; then
-        $IP6TABLES -t $table -F $chain
+        $IP6TABLES {{$opt_wait}} -t $table -F $chain
       fi
   done
-  $IP6TABLES -t $table -X
+  $IP6TABLES {{$opt_wait}} -t $table -X
 done
 }
 

--- a/src/res/configlets/linux24/reset_iptables
+++ b/src/res/configlets/linux24/reset_iptables
@@ -12,32 +12,38 @@
 ## {{if var}} is conditional operator.
 ##
 reset_iptables_v4() {
+  local list
+
   $IPTABLES {{$opt_wait}} -P OUTPUT  DROP
   $IPTABLES {{$opt_wait}} -P INPUT   DROP
   $IPTABLES {{$opt_wait}} -P FORWARD DROP
 
-cat /proc/net/ip_tables_names | while read table; do
-  $IPTABLES {{$opt_wait}} -t $table -L -n | while read c chain rest; do
+  while read table; do
+      list=$($IPTABLES {{$opt_wait}} -t $table -L -n)
+      printf "%s" "$list" | while read c chain rest; do
       if test "X$c" = "XChain" ; then
         $IPTABLES {{$opt_wait}} -t $table -F $chain
       fi
-  done
-  $IPTABLES {{$opt_wait}} -t $table -X
-done
+      done
+      $IPTABLES {{$opt_wait}} -t $table -X
+  done < /proc/net/ip_tables_names
 }
 
 reset_iptables_v6() {
+  local list
+
   $IP6TABLES {{$opt_wait}} -P OUTPUT  DROP
   $IP6TABLES {{$opt_wait}} -P INPUT   DROP
   $IP6TABLES {{$opt_wait}} -P FORWARD DROP
 
-cat /proc/net/ip6_tables_names | while read table; do
-  $IP6TABLES {{$opt_wait}} -t $table -L -n | while read c chain rest; do
+  while read table; do
+      list=$($IP6TABLES {{$opt_wait}} -t $table -L -n)
+      printf "%s" "$list" | while read c chain rest; do
       if test "X$c" = "XChain" ; then
         $IP6TABLES {{$opt_wait}} -t $table -F $chain
       fi
-  done
-  $IP6TABLES {{$opt_wait}} -t $table -X
-done
+      done
+      $IP6TABLES {{$opt_wait}} -t $table -X
+  done < /proc/net/ip6_tables_names
 }
 

--- a/src/res/configlets/linux24/stop_action
+++ b/src/res/configlets/linux24/stop_action
@@ -20,15 +20,15 @@ stop_action() {
     reset_all
 
 {{if have_ipv4}}
-    $IPTABLES -P OUTPUT  ACCEPT
-    $IPTABLES -P INPUT   ACCEPT
-    $IPTABLES -P FORWARD ACCEPT
+    $IPTABLES {{$opt_wait}} -P OUTPUT  ACCEPT
+    $IPTABLES {{$opt_wait}} -P INPUT   ACCEPT
+    $IPTABLES {{$opt_wait}} -P FORWARD ACCEPT
 {{endif}}
 
 {{if have_ipv6}}
-    $IP6TABLES -P OUTPUT  ACCEPT
-    $IP6TABLES -P INPUT   ACCEPT
-    $IP6TABLES -P FORWARD ACCEPT
+    $IP6TABLES {{$opt_wait}} -P OUTPUT  ACCEPT
+    $IP6TABLES {{$opt_wait}} -P INPUT   ACCEPT
+    $IP6TABLES {{$opt_wait}} -P FORWARD ACCEPT
 {{endif}}
 }
 

--- a/src/res/templates.xml.in
+++ b/src/res/templates.xml.in
@@ -104,7 +104,7 @@
         <CustomServiceCommand platform="iosacl">established</CustomServiceCommand>
         <CustomServiceCommand platform="ipfilter"/>
         <CustomServiceCommand platform="ipfw">established</CustomServiceCommand>
-        <CustomServiceCommand platform="iptables">-m state --state ESTABLISHED,RELATED</CustomServiceCommand>
+        <CustomServiceCommand platform="iptables">-m conntrack --ctstate ESTABLISHED,RELATED</CustomServiceCommand>
         <CustomServiceCommand platform="procurve_acl">established</CustomServiceCommand>
       </CustomService>
       <CustomService id="stdid14_2" name="ESTABLISHED ipv6" comment="This service matches all packets which are part of network connections established through the firewall, or connections 'related' to those established through the firewall. Term 'established' refers to the state tracking mechanism which exists inside iptables and other stateful firewalls and does not mean any particular combination of packet header options. Packet is considered to correspond to the state 'ESTABLISHED' if it belongs to the network session, for which proper initiation has been seen by the firewall, so its stateful inspection module made appropriate record in the state table. Usually stateful firewalls keep track of network connections using not only tcp protocol, but also udp and sometimes even icmp protocols. 'RELATED' describes packet belonging to a separate network connection, related to the session firewall is keeping track of. One example is FTP command and FTP data sessions." ro="False" protocol="any" address_family="ipv6">
@@ -112,7 +112,7 @@
         <CustomServiceCommand platform="iosacl">established</CustomServiceCommand>
         <CustomServiceCommand platform="ipfilter"/>
         <CustomServiceCommand platform="ipfw">established</CustomServiceCommand>
-        <CustomServiceCommand platform="iptables">-m state --state ESTABLISHED,RELATED</CustomServiceCommand>
+        <CustomServiceCommand platform="iptables">-m conntrack --ctstate ESTABLISHED,RELATED</CustomServiceCommand>
         <CustomServiceCommand platform="procurve_acl">established</CustomServiceCommand>
       </CustomService>
       <ServiceGroup id="stdid10" name="Groups" comment="" ro="False">


### PR DESCRIPTION
These commits
A) replace "-m state --state" with "-m conntrack --ctstate" for iptable >= 1.4.4 to suppress warnings thath "-m state" is deprecated
B) add a "-m" option to iptables >= 1.4.20 to request waiting instead of bailing out when iptables is locked with the new (1.4.20) xtables lock.