### PR TITLE
better readme and support for Qt5

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,22 @@ Installation instructions
 Ubuntu
 ---------
 
+The instructions are inspired by the well-meaning but out of date instructions available from the fwbuilder.org website: http://www.fwbuilder.org/4.0/docs/users_guide5/compile_from_source.shtml
+
 run the following apt-get install command to install the compile requirements:
 
+```
  sudo apt-get install git automake autoconf libtool libxml2-dev libxslt-dev libsnmp-dev qt4-dev-tools
  git clone https://github.com/fwbuilder/fwbuilder.git
  cd fwbuilder
  ./autogen.sh
  make
  sudo make install
-
+```
 Then, if you are lucky, you should be able to type
-
+```
  fwbuilder &
-
+```
 At the prompt and get it to run. There is also a GUI icon you can use to start the program. 
+
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The instructions are inspired by the well-meaning but out of date instructions a
 run the following apt-get install command to install the compile requirements:
 
 ```
- sudo apt-get install git automake autoconf libtool libxml2-dev libxslt-dev libsnmp-dev qt4-dev-tools
+ sudo apt-get install git automake autoconf libtool libxml2-dev libxslt-dev libsnmp-dev qt5-default qttools5-dev-tools
  git clone https://github.com/fwbuilder/fwbuilder.git
  cd fwbuilder
  ./autogen.sh

--- a/README.md
+++ b/README.md
@@ -4,3 +4,27 @@ fwbuilder
 =========
 
 Firewall Builder is a GUI firewall management application for iptables, PF, Cisco ASA/PIX/FWSM, Cisco router ACL and more. Firewall configuration data is stored in a central file that can scale to hundreds of firewalls managed from a single UI.
+
+
+Installation instructions
+=========================
+
+
+Ubuntu
+---------
+
+run the following apt-get install command to install the compile requirements:
+
+ sudo apt-get install git automake autoconf libtool libxml2-dev libxslt-dev libsnmp-dev qt4-dev-tools
+ git clone https://github.com/fwbuilder/fwbuilder.git
+ cd fwbuilder
+ ./autogen.sh
+ make
+ sudo make install
+
+Then, if you are lucky, you should be able to type
+
+ fwbuilder &
+
+At the prompt and get it to run. There is also a GUI icon you can use to start the program. 
+

--- a/fwbuilder3.pro
+++ b/fwbuilder3.pro
@@ -19,3 +19,4 @@ clean_tests.commands = ./unit_tests.sh make clean_tests
 
 QMAKE_EXTRA_TARGETS += build_tests run_tests clean_tests tests 
 
+QT += widgets


### PR DESCRIPTION
redid the readme with instructions for Qt5 instead of Qt4.

I also tried to recompile using QT5 and it crashed. I looked up the bug and applied the following fix:

https://stackoverflow.com/a/21554163

This pull request now includes Qt5 installation instructions along with the small change to fwbuilder3.pro need to get the Qt5 compilation to work..

Regards,
-FT