### PR TITLE
Some minor build system tweaks

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -48,4 +48,4 @@ which acinclude >/dev/null 2>&1 && acinclude
 which aclocal >/dev/null 2>&1 && aclocal
 autoconf
 
-./configure ${CFGARGS}  $*
+test -n "$NOCONFIGURE" || ./configure ${CFGARGS}  $*

--- a/runqmake.sh
+++ b/runqmake.sh
@@ -13,5 +13,10 @@ IFS="
 
 test -z "$EXTRA_CXXFLAGS" || FLAGS="QMAKE_CXXFLAGS += $EXTRA_CXXFLAGS"
 
-$QMAKE "$FLAGS" $C
+if [ -z "$FLAGS" ]; then
+  # in case there are no FLAGS defined, we can't pass an empty "" parameter to qmake
+  $QMAKE $C
+else
+  $QMAKE "$FLAGS" $C
+fi
 


### PR DESCRIPTION
* autogen.sh: allow to skip configure

Most distros that will package fwbuilder wiill use some macro-style version on how to call confgure (rpm based ones have %configure); the implicit call from autogen.sh just means those have to run configure twice

* runqmake.sh: in case $FLAGS is empty, we run qmake "" -recursive, which leads to an error like:

```
[  115s] QTDIR=""
[  115s] Running qmake: /usr/bin/qmake-qt5 -recursive
[  115s] Empty filename passed to function
[  115s] Cannot find file: .
```

Note that echo "$FLAGS" is swallows the quotes, running qmake "$FLAGS" though passes an empty string between quotes to qmake as argv[1]