### PR TITLE
Update interface pattern for VLANs with predictable device naming

### DIFF
--- a/src/compiler_lib/linux24Interfaces.cpp
+++ b/src/compiler_lib/linux24Interfaces.cpp
@@ -42,7 +42,7 @@ using namespace libfwbuilder;
 bool linux24Interfaces::parseVlan(const QString &name, QString *base_name, int *vlan_id)
 {
     QList<QRegExp> vlan_name_patterns;
-    vlan_name_patterns.append(QRegExp("([a-zA-Z-]+\\d{1,})\\.(\\d{1,})"));
+    vlan_name_patterns.append(QRegExp("([a-zA-Z0-9-]+\\d{1,})\\.(\\d{1,})"));
     vlan_name_patterns.append(QRegExp("(vlan)(\\d{1,})"));
     for (int idx=0; idx < vlan_name_patterns.size(); ++idx)
     {


### PR DESCRIPTION
The existing regexp to Linux interface names with VLANs (e.g. eth0.10) fails with the new style predictable device names (e.g. enp0s20f2.10), causing fwbuilder to reject the interface name. This makes it impossible to build firewall configurations on recent distributions without disabling predictable device naming.
Update regexp to allow matching of newer style device names