### PR TITLE
fix: demote GCC maybe-uninitialized error to warning again

### DIFF
--- a/qmake.inc.in
+++ b/qmake.inc.in
@@ -199,8 +199,8 @@ FWB_SIG = $$(FWB_SIG)
 if (isEmpty(FWB_SIG)) { FWB_SIG=26932 }
 DEFINES += FWB_SIG=$$FWB_SIG
 
-QMAKE_CXXFLAGS_DEBUG += -D__STDC_FORMAT_MACROS -Wall -Wextra -Werror $$(CXXFLAGS)
-QMAKE_CXXFLAGS_RELEASE += -D__STDC_FORMAT_MACROS -Wall -Wextra -Werror $$(CXXFLAGS)
+QMAKE_CXXFLAGS_DEBUG += -D__STDC_FORMAT_MACROS -Wall -Wextra -Werror -Wno-error=maybe-uninitialized $$(CXXFLAGS)
+QMAKE_CXXFLAGS_RELEASE += -D__STDC_FORMAT_MACROS -Wall -Wextra -Werror -Wno-error=maybe-uninitialized $$(CXXFLAGS)
 
 exists(qmake2.inc) {
   include(qmake2.inc)

--- a/src/libfwbuilder/qmake.inc.in
+++ b/src/libfwbuilder/qmake.inc.in
@@ -16,8 +16,8 @@ CPPUNIT_LIBS = @CPPUNIT_LIBS@
 CONFIG -= qt
 CONFIG += c++14
 
-QMAKE_CXXFLAGS_DEBUG += -D__STDC_FORMAT_MACROS -Wall -Wextra -Werror $$(CXXFLAGS)
-QMAKE_CXXFLAGS_RELEASE += -D__STDC_FORMAT_MACROS -Wall -Wextra -Werror $$(CXXFLAGS)
+QMAKE_CXXFLAGS_DEBUG += -D__STDC_FORMAT_MACROS -Wall -Wextra -Werror -Wno-error=maybe-uninitialized $$(CXXFLAGS)
+QMAKE_CXXFLAGS_RELEASE += -D__STDC_FORMAT_MACROS -Wall -Wextra -Werror -Wno-error=maybe-uninitialized $$(CXXFLAGS)
 
 
 unix {


### PR DESCRIPTION
After enabling stricter compile warnings with the following commit
https://github.com/fwbuilder/fwbuilder/commit/302299ec52956c98f2cbf0a6a6056c3ae458925f
it is necessary to add "-Wno-error=maybe-uninitialized" to CXXFLAGS, otherwise the compile fails with gcc-7.3.0/gcc-8.2.0:

../fwbuilder/FWObject.h:64:65: warning: 'nserv' may be used uninitialized in this function [-Wmaybe-uninitialized]
PIXImporter.cpp:968:40: warning: 'obj' may be used uninitialized in this function [-Wmaybe-uninitialized]
linux24Interfaces.cpp:279:21: warning: 'itype' may be used uninitialized in this function [-Wmaybe-uninitialized]
RuleSetDiffDialog.cpp:179:101: warning: 'originalRuleSetModel' may be used uninitialized in this function [-Wmaybe-uninitialized]
RuleSetDiffDialog.cpp:186:99: warning: 'currentRuleSetModel' may be used uninitialized in this function [-Wmaybe-uninitialized]