### PR TITLE
Prepare w32-bin-folder with Windows-dependencies.

### DIFF
--- a/build_mxe-w32.sh
+++ b/build_mxe-w32.sh
@@ -66,9 +66,38 @@ compile()
     fi
 }
 
+prepare_w32_bin()
+{
+    pushd "release/install-root"
+    if [ -d "w32-bin" ]
+    then
+        popd
+        return
+    fi
+
+    mkdir "w32-bin"
+    pushd "w32-bin"
+
+    mkdir "rcs"
+    pushd "rcs"
+    wget  "www.cs.purdue.edu/homes/trinkle/RCS/rcs57pc1.zip"
+    unzip "rcs57pc1.zip"
+    popd
+
+    mkdir "putty"
+    pushd "putty"
+    wget  "http://the.earth.li/~sgtatham/putty/latest/x86/plink.exe"
+    wget  "http://the.earth.li/~sgtatham/putty/latest/x86/pscp.exe"
+    popd
+
+    popd
+    popd
+}
+
 package()
 {
     echo "==> Packaging"
+    prepare_w32_bin
     makensis release/install-root/fwbuilder.nsi
     if [ $? -eq 0 ]; then
         echo "==> Done packaging"

--- a/packaging/fwbuilder.nsi.in
+++ b/packaging/fwbuilder.nsi.in
@@ -286,17 +286,17 @@ Section "FWBuilder (required)"
 
 ; Install RCS for these files
 ;
-  File "w32-bin\ci.exe"
-  File "w32-bin\co.exe"
-  File "w32-bin\rcs.exe"
-  File "w32-bin\rcsdiff.exe"
-  File "w32-bin\rlog.exe"
-  File "w32-bin\diff.exe"
-  File "w32-bin\rcslib.dll"
+  File "w32-bin/rcs/bin/win32/ci.exe"
+  File "w32-bin/rcs/bin/win32/co.exe"
+  File "w32-bin/rcs/bin/win32/diff.exe"
+  File "w32-bin/rcs/bin/win32/rcs.exe"
+  File "w32-bin/rcs/bin/win32/rcsdiff.exe"
+  File "w32-bin/rcs/bin/win32/rcslib.dll"
+  File "w32-bin/rcs/bin/win32/rlog.exe"
 
 ;; Starting with 4.0.2, we now package putty tools with fwbuilder
-  File "w32-bin\plink.exe"
-  File "w32-bin\pscp.exe"
+  File "w32-bin/putty/plink.exe"
+  File "w32-bin/putty/pscp.exe"
 
 
 ; Write the installation path into the registry


### PR DESCRIPTION
In #68 I recognized that the default build script doesn't seem to handle the folder `w32_bin` mentioned in the NSI-script, so I added a function to download the necessary dependencies. This is pretty much the same like has been done in the past:

https://github.com/fwbuilder/fwbuilder/blob/master/doc/README.windows#L125

Consider this a PoC and feel free to choose another solution.