### PR TITLE
Set a white text color if the background is dark

### DIFF
--- a/src/libgui/utils.cpp
+++ b/src/libgui/utils.cpp
@@ -310,7 +310,7 @@ void setDisabledPalette(QWidget *w)
 
     pal.setCurrentColorGroup( QPalette::Normal );
 
-    QColor textColor = Qt::black
+    QColor textColor = Qt::black;
     if ( qGray(pal.color(QPalette::Window).rgba()) < 100) {
         textColor = Qt::white;
     }

--- a/src/libgui/utils.cpp
+++ b/src/libgui/utils.cpp
@@ -308,14 +308,21 @@ void setDisabledPalette(QWidget *w)
 {
     QPalette    pal=w->palette();
 
+    pal.setCurrentColorGroup( QPalette::Normal );
+
+    QColor textColor = Qt::black
+    if ( qGray(pal.color(QPalette::Window).rgba()) < 100) {
+        textColor = Qt::white;
+    }
+
     pal.setCurrentColorGroup( QPalette::Active );
-    pal.setColor( QPalette::Text, Qt::black );
+    pal.setColor( QPalette::Text, textColor );
 
     pal.setCurrentColorGroup( QPalette::Inactive );
-    pal.setColor( QPalette::Text, Qt::black );
+    pal.setColor( QPalette::Text, textColor );
 
     pal.setCurrentColorGroup( QPalette::Disabled );
-    pal.setColor( QPalette::Text, Qt::black );
+    pal.setColor( QPalette::Text, textColor );
 
     w->setPalette( pal );
 }


### PR DESCRIPTION
This checks that the "grayness" of the background is less than 100
and switches to use white for the text color if so.

Testing against a dark theme here suggests that this helps a lot. The
"grayness" for a dark theme is typically less than 60, but contrast issues
should start to disappear around 100.