### PR TITLE
Dark theme is usable

### DIFF
--- a/src/libgui/ProjectPanel_file_ops.cpp
+++ b/src/libgui/ProjectPanel_file_ops.cpp
@@ -1048,6 +1048,12 @@ bool ProjectPanel::loadFromRCS(RCS *_rcs)
         objdb->load( Constants::getStandardObjectsFilePath(),
                      &upgrade_predicate, Constants::getDTDDirectory());
         objdb->setFileName("");
+        if ( qGray(palette().color(QPalette::Window).rgba()) < 100) {
+            FWObject *stdLib = objdb->findObjectByName(Library::TYPENAME, "Standard");
+            stdLib->setReadOnly(false);
+            stdLib->setStr("color", "#0a0f1f");
+            objdb->setDirty(false);
+        }
 
 // objects from a data file are in database ndb
 

--- a/src/libgui/ProjectPanel_file_ops.cpp
+++ b/src/libgui/ProjectPanel_file_ops.cpp
@@ -963,7 +963,13 @@ void ProjectPanel::loadStandardObjects()
         FWObject *userLib = FWBTree().createNewLibrary(objdb);
 
         userLib->setName("User");
-        userLib->setStr("color","#d2ffd0");
+        if ( qGray(palette().color(QPalette::Window).rgba()) < 100) {
+            // Window is using a dark palette, so we default to a very dark green for background
+            userLib->setStr("color","#0a1f08");
+        } else {
+            // Window is using a light palette, so we default to a light green background
+            userLib->setStr("color","#d2ffd0");
+        }
 
         objdb->setDirty(false);
         objdb->setFileName("");

--- a/src/libgui/ProjectPanel_file_ops.cpp
+++ b/src/libgui/ProjectPanel_file_ops.cpp
@@ -957,6 +957,12 @@ void ProjectPanel::loadStandardObjects()
         objdb->load( Constants::getStandardObjectsFilePath(),
                      &upgrade_predicate, Constants::getDTDDirectory());
         objdb->setFileName("");
+        if ( qGray(palette().color(QPalette::Window).rgba()) < 100) {
+            FWObject *stdLib = objdb->findObjectByName(Library::TYPENAME, "Standard");
+            stdLib->setReadOnly(false);
+            stdLib->setStr("color", "#0a0f1f");
+            objdb->setDirty(false);
+        }
 
         if (fwbdebug) qDebug("ProjectPanel::load(): create User library");
 

--- a/src/libgui/RuleSetView.cpp
+++ b/src/libgui/RuleSetView.cpp
@@ -166,7 +166,12 @@ void RuleSetView::init()
      * RuleSetViewDelegate when I paint individual cells.
      */
     QPalette updated_palette = palette();
-    updated_palette.setColor(QPalette::Highlight, QColor("silver"));
+    if ( qGray(updated_palette.color(QPalette::Window).rgba()) < 100) {
+        // Window is using a dark palette, so we just lighten a little for the highlight
+        updated_palette.setColor(QPalette::Highlight, updated_palette.color(QPalette::Window).lighter(150));
+    } else {
+        updated_palette.setColor(QPalette::Highlight, QColor("silver"));
+    }
     setPalette(updated_palette);
 
 

--- a/src/libgui/utils.cpp
+++ b/src/libgui/utils.cpp
@@ -310,7 +310,7 @@ void setDisabledPalette(QWidget *w)
 
     pal.setCurrentColorGroup( QPalette::Normal );
 
-    QColor textColor = Qt::black
+    QColor textColor = Qt::black;
     if ( qGray(pal.color(QPalette::Window).rgba()) < 100) {
         textColor = Qt::white;
     }

--- a/src/libgui/utils.cpp
+++ b/src/libgui/utils.cpp
@@ -308,14 +308,21 @@ void setDisabledPalette(QWidget *w)
 {
     QPalette    pal=w->palette();
 
+    pal.setCurrentColorGroup( QPalette::Normal );
+
+    QColor textColor = Qt::black
+    if ( qGray(pal.color(QPalette::Window).rgba()) < 100) {
+        textColor = Qt::white;
+    }
+
     pal.setCurrentColorGroup( QPalette::Active );
-    pal.setColor( QPalette::Text, Qt::black );
+    pal.setColor( QPalette::Text, textColor );
 
     pal.setCurrentColorGroup( QPalette::Inactive );
-    pal.setColor( QPalette::Text, Qt::black );
+    pal.setColor( QPalette::Text, textColor );
 
     pal.setCurrentColorGroup( QPalette::Disabled );
-    pal.setColor( QPalette::Text, Qt::black );
+    pal.setColor( QPalette::Text, textColor );
 
     w->setPalette( pal );
 }


### PR DESCRIPTION
This is replacement / extension to pull request #78 which makes fwbuilder fully usable with a dark theme and potentially closes issue #28 - well, it "Works For Me" under Debian + Cinnamon :-)

While I do think there are better solutions I believe that they would involve significant effort re-writing the way fwbuilder skins the GUI and would either be a (good) intern working on it for a month, or someone with lots of experience with the code base working on it for a week or two.

My intention with these small changes is to provide a pragmatic, uninvasive solution that does not affect the complexity of such future work, but which does make fwbuilder usable right now.

I might have missed some areas where readability is still a problem, and I'm happy to look into those areas also, if you can make me aware of them.

Comments welcome!  Merry Christmas!