### PR TITLE
error: Name of the VLAN interface 'bond0.101' does not match any ...

### DIFF
--- a/src/iptlib/OSConfigurator_linux24_interfaces.cpp
+++ b/src/iptlib/OSConfigurator_linux24_interfaces.cpp
@@ -305,14 +305,14 @@ string OSConfigurator_linux24::printVlanInterfaceConfigurationCommands()
                     if (vlan_name == sintf_name) name_type = "VLAN_PLUS_VID_NO_PAD";
                     else
                     {
-                        vlan_name = QString("vlan%1.%2")
+                        vlan_name = QString("%1.%2")
                                 .arg(iface->getName().c_str())
                                 .arg(vlan_id, 4, 10, QChar('0'));
                         supported_vlan_names.append(vlan_name);
                         if (vlan_name == sintf_name) name_type = "DEV_PLUS_VID_PAD";
                         else
                         {
-                            vlan_name = QString("vlan%1.%2")
+                            vlan_name = QString("%1.%2")
                                     .arg(iface->getName().c_str())
                                     .arg(vlan_id);
                             supported_vlan_names.append(vlan_name);


### PR DESCRIPTION
…supported naming type for VLAN interfaces. Possible names: vlan0101, vlan101, vlanbond0.0101, vlanbond0.101

ded1340898d11d411059aaa305250df4ef3051d6 made our rulesets not compileable.
