### PR TITLE
Building using MXE on UB 18.04 fails without ws2_32 being linked.

### DIFF
--- a/src/iosacl/CMakeLists.txt
+++ b/src/iosacl/CMakeLists.txt
@@ -7,7 +7,7 @@ add_executable(fwb_iosacl ${iosacl_srcs})
 target_link_libraries(fwb_iosacl common fwbcisco compilerdriver fwcompiler fwbuilder xml2 pthread m xslt z)
 
 IF (WIN32)
-  target_link_libraries(fwb_iosacl lzma iconv)
+  target_link_libraries(fwb_iosacl lzma iconv ws2_32)
 ENDIF()
 
 IF (UNIX)

--- a/src/ipf/CMakeLists.txt
+++ b/src/ipf/CMakeLists.txt
@@ -6,7 +6,7 @@ add_executable(fwb_ipf ${ipf_srcs})
 target_link_libraries(fwb_ipf common fwbpf compilerdriver fwcompiler fwbuilder xml2 pthread m xslt z)
 
 IF (WIN32)
-  target_link_libraries(fwb_ipf lzma iconv)
+  target_link_libraries(fwb_ipf lzma iconv ws2_32)
 ENDIF()
 
 IF (UNIX)

--- a/src/ipfw/CMakeLists.txt
+++ b/src/ipfw/CMakeLists.txt
@@ -6,7 +6,7 @@ add_executable(fwb_ipfw ${ipfw_srcs})
 target_link_libraries(fwb_ipfw common fwbpf compilerdriver fwcompiler fwbuilder xml2 pthread m xslt z)
 
 IF (WIN32)
-  target_link_libraries(fwb_ipfw lzma iconv)
+  target_link_libraries(fwb_ipfw lzma iconv ws2_32)
 ENDIF()
 
 IF (UNIX)

--- a/src/iptlib/CMakeLists.txt
+++ b/src/iptlib/CMakeLists.txt
@@ -33,6 +33,10 @@ target_include_directories(iptlib PUBLIC
 
 target_link_libraries(iptlib compilerdriver)
 
+IF (WIN32)
+  target_link_libraries(iptlib compilerdriver ws2_32)
+ENDIF()
+
 target_compile_options(iptlib PRIVATE ${CXX_DEFAULT_FLAGS})
 
 qt5_use_modules(iptlib Core)

--- a/src/junosacl/CMakeLists.txt
+++ b/src/junosacl/CMakeLists.txt
@@ -7,7 +7,7 @@ add_executable(fwb_junosacl ${junosacl_srcs})
 target_link_libraries(fwb_junosacl common fwbcisco fwbjuniper compilerdriver fwcompiler fwbuilder xml2 pthread m xslt z)
 
 IF (WIN32)
-  target_link_libraries(fwb_junosacl iconv lzma)
+  target_link_libraries(fwb_junosacl iconv lzma ws2_32)
 ENDIF()
 
 IF (UNIX)

--- a/src/nxosacl/CMakeLists.txt
+++ b/src/nxosacl/CMakeLists.txt
@@ -7,7 +7,7 @@ add_executable(fwb_nxosacl ${nxosacl_srcs})
 target_link_libraries(fwb_nxosacl common fwbcisco compilerdriver fwcompiler fwbuilder xml2 pthread m xslt z)
 
 IF (WIN32)
-  target_link_libraries(fwb_nxosacl lzma iconv)
+  target_link_libraries(fwb_nxosacl lzma iconv ws2_32)
 ENDIF()
 
 IF (UNIX)

--- a/src/pf/CMakeLists.txt
+++ b/src/pf/CMakeLists.txt
@@ -6,7 +6,7 @@ add_executable(fwb_pf ${pf_srcs})
 target_link_libraries(fwb_pf common fwbpf compilerdriver fwcompiler fwbuilder xml2 pthread m xslt z)
 
 IF (WIN32)
-  target_link_libraries(fwb_pf lzma iconv)
+  target_link_libraries(fwb_pf lzma iconv ws2_32)
 ENDIF()
 
 IF (UNIX)

--- a/src/pix/CMakeLists.txt
+++ b/src/pix/CMakeLists.txt
@@ -6,7 +6,7 @@ add_executable(fwb_pix ${pix_srcs})
 target_link_libraries(fwb_pix common fwbcisco compilerdriver fwcompiler fwbuilder xml2 pthread m xslt z)
 
 IF (WIN32)
-  target_link_libraries(fwb_pix lzma iconv)
+  target_link_libraries(fwb_pix lzma iconv ws2_32)
 ENDIF()
 
 IF (UNIX)

--- a/src/procurve_acl/CMakeLists.txt
+++ b/src/procurve_acl/CMakeLists.txt
@@ -7,7 +7,7 @@ add_executable(fwb_procurve_acl ${procurve_acl_srcs})
 target_link_libraries(fwb_procurve_acl common fwbcisco compilerdriver fwcompiler fwbuilder xml2 pthread m xslt z)
 
 IF (WIN32)
-  target_link_libraries(fwb_procurve_acl lzma iconv)
+  target_link_libraries(fwb_procurve_acl lzma iconv ws2_32)
 ENDIF()
 
 IF (UNIX)


### PR DESCRIPTION
Error messages like the following occur:

    [ 26%] Linking CXX executable fwb_ipt.exe
    ../iptlib/libiptlib.a(PolicyCompiler_ipt.cpp.obj):PolicyCompiler_ipt.cpp:(.text+0x1a23): undefined reference to `_imp__ntohl@4'

Similar problems have been reported on other projects and the solution always was to link `ws2_32`, like in the following example:

https://github.com/kohler/lcdf-typetools/issues/22

Applying this PR makes things build on my UB 18.04. Note, though, that I'm not using Docker or else, but simply installed MXE manually and followed pretty much what you have done in the shell scripts for Docker and Travis regarding MXE. Shouldn't make a difference in my opinion, if at all the concrete version of MXE might make a difference. While you are explicitly using a specific commit, I was simply using the master cloned a week or two before.

You: 0567f17d34463abda1790957812c54e8c0cf59fe 

vs. 

Me:

    commit 951c528c4e75fca058f491f0894fdb389294b61c (HEAD -> master, origin/master, origin/HEAD)
    Author: MXEBot as Travis CI <mxebot@gmail.com>
    Date:   Wed Apr 22 09:45:36 2020 +0000

    Update packages.json & build-matrix.html