### PR TITLE
Error "Firewall Builder: Unknown option 'n'." when opening files on Windows using double-click.

### DIFF
--- a/packaging/fwbuilder.nsi.in
+++ b/packaging/fwbuilder.nsi.in
@@ -192,12 +192,12 @@ Section "FWBuilder (required)"
 ; Write file associations and icons
 
   WriteRegStr HKLM "Software\Classes\.fwb" "" "fwbfile"
-  WriteRegStr HKLM "Software\Classes\fwbfile\shell\open\command" "" "$INSTDIR\fwbuilder.exe %1"
-  WriteRegStr HKLM "Software\Classes\fwbfile\DefaultIcon"        "" "$INSTDIR\fwbuilder.exe,0"
+  WriteRegStr HKLM "Software\Classes\fwbfile\shell\open\command" "" '"$INSTDIR\fwbuilder.exe" "%1"'
+  WriteRegStr HKLM "Software\Classes\fwbfile\DefaultIcon"        "" '"$INSTDIR\fwbuilder.exe,0"'
 
   WriteRegStr HKLM "Software\Classes\.fwl" "" "fwlfile"
-  WriteRegStr HKLM "Software\Classes\fwlfile\shell\open\command" "" "$INSTDIR\fwbuilder.exe %1"
-  WriteRegStr HKLM "Software\Classes\fwlfile\DefaultIcon"        "" "$INSTDIR\fwbuilder.exe,0"
+  WriteRegStr HKLM "Software\Classes\fwlfile\shell\open\command" "" '"$INSTDIR\fwbuilder.exe" "%1"'
+  WriteRegStr HKLM "Software\Classes\fwlfile\DefaultIcon"        "" '"$INSTDIR\fwbuilder.exe,0"'
 
 
 ; Create registry entry for putty session with ssh keepalive

--- a/packaging/fwbuilder.nsi.in
+++ b/packaging/fwbuilder.nsi.in
@@ -192,11 +192,11 @@ Section "FWBuilder (required)"
 ; Write file associations and icons
 
   WriteRegStr HKLM "Software\Classes\.fwb" "" "fwbfile"
-  WriteRegStr HKLM "Software\Classes\fwbfile\shell\open\command" "" "$INSTDIR\fwbuilder.exe -noexec %1"
+  WriteRegStr HKLM "Software\Classes\fwbfile\shell\open\command" "" "$INSTDIR\fwbuilder.exe %1"
   WriteRegStr HKLM "Software\Classes\fwbfile\DefaultIcon"        "" "$INSTDIR\fwbuilder.exe,0"
 
   WriteRegStr HKLM "Software\Classes\.fwl" "" "fwlfile"
-  WriteRegStr HKLM "Software\Classes\fwlfile\shell\open\command" "" "$INSTDIR\fwbuilder.exe -noexec %1"
+  WriteRegStr HKLM "Software\Classes\fwlfile\shell\open\command" "" "$INSTDIR\fwbuilder.exe %1"
   WriteRegStr HKLM "Software\Classes\fwlfile\DefaultIcon"        "" "$INSTDIR\fwbuilder.exe,0"
 
 
@@ -207,7 +207,7 @@ Section "FWBuilder (required)"
 ; ========================================================================
 ; Configure installer to use our prepackaged plink.exe and pscp.exe but only if it was not configured before
 ;
-; ******** THESE KEYS MUST MATCH THOSE USED BY the class FWBSettings 
+; ******** THESE KEYS MUST MATCH THOSE USED BY the class FWBSettings
 ;
   ReadRegStr $0 HKCU "Software\firewallbuilder.org\${APPNAME}\${GENERATION}\SSH" "SSHPath"
   StrCmp $0 "" 0 +3


### PR DESCRIPTION
I've installed FWBuilder 6 for Windows, which registers a file handler to open files by double-click in Windows Explorer. Though, whenever I did so I got the following error message:

```
---------------------------
Firewall Builder
---------------------------
Firewall Builder: Unknown option 'n'.

---------------------------
OK   
---------------------------
```

The installer registered the following OPEN-command:

    Computer\HKEY_CLASSES_ROOT\fwbfile\shell\open\command
    C:\Program Files (x86)\FWBuilder6.0\fwbuilder.exe -noexec %1

After removing `-noexec` opening succeeds without an error message. I can only find the string `noexec` in the NSI-files, nowhere else, so it seems like a left-over from a former change. While I was at it, quoted the paths as well, just to be sure and because other places like `UninstallString` above did so already.