### PR TITLE
Create start menu entries for all users.

### DIFF
--- a/packaging/fwbuilder.nsi.in
+++ b/packaging/fwbuilder.nsi.in
@@ -217,10 +217,7 @@ Section "FWBuilder (required)"
 
   !insertmacro MUI_STARTMENU_WRITE_BEGIN Application
 
-; Setting var context to "all" makes Start menu shortcuts appear for all
-; users
-
-;  SetShellVarContext all
+  SetShellVarContext all
 
   CreateDirectory "$SMPROGRAMS\$STARTMENU_FOLDER"
   CreateShortCut "$SMPROGRAMS\$STARTMENU_FOLDER\FWBuilder.lnk" "$INSTDIR\fwbuilder.exe" "" "$INSTDIR\fwbuilder.exe"


### PR DESCRIPTION
The Windows installer created start menu entries for the current user only, but requested elevation. In setups in which admins and non-admin users exist, this lead to unavailable start menu entries for non-admin users. The support for that was already available, but has been added commented for some reason.