### PR TITLE
OpenBSD: requires <sys/stat.h> for stat(2)

### DIFF
--- a/src/libfwbuilder/src/fwbuilder/Constants.cpp
+++ b/src/libfwbuilder/src/fwbuilder/Constants.cpp
@@ -25,7 +25,7 @@
 #include "version.h"
 #include "fwbuilder/Constants.h"
 
-#if defined (__linux__) || defined (__FreeBSD_kernel__) || defined (__MINGW64__) || defined (__MINGW32__) || defined (__APPLE__)
+#if defined (__linux__) || defined (__FreeBSD_kernel__) || defined (__OpenBSD__) || defined (__MINGW64__) || defined (__MINGW32__) || defined (__APPLE__)
 #   include <sys/stat.h>
 #endif
 


### PR DESCRIPTION
Hi,

OpenBSD requires [<sys/stat.h>](https://man.openbsd.org/stat.2) for stat(2).