### PR TITLE
Use ${CMAKE_DL_LIBS} for portability

### DIFF
--- a/src/fwbedit/CMakeLists.txt
+++ b/src/fwbedit/CMakeLists.txt
@@ -19,7 +19,7 @@ IF (WIN32)
 ENDIF()
 
 IF (UNIX)
-  target_link_libraries(fwbedit c dl util)
+  target_link_libraries(fwbedit c ${CMAKE_DL_LIBS} util)
 ENDIF()
 
 IF (NETSNMP_FOUND)

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -20,7 +20,7 @@ IF (WIN32)
 ENDIF()
 
 IF (UNIX)
-  target_link_libraries(fwbuilder-gui c dl util)
+  target_link_libraries(fwbuilder-gui c ${CMAKE_DL_LIBS} util)
 ENDIF()
 
 IF (NETSNMP_FOUND)

--- a/src/iosacl/CMakeLists.txt
+++ b/src/iosacl/CMakeLists.txt
@@ -10,7 +10,7 @@ IF (WIN32)
 ENDIF()
 
 IF (UNIX)
-  target_link_libraries(fwb_iosacl c dl util)
+  target_link_libraries(fwb_iosacl c ${CMAKE_DL_LIBS} util)
 ENDIF()
 
 target_compile_options(fwb_iosacl PRIVATE ${CXX_DEFAULT_FLAGS})

--- a/src/ipf/CMakeLists.txt
+++ b/src/ipf/CMakeLists.txt
@@ -10,7 +10,7 @@ IF (WIN32)
 ENDIF()
 
 IF (UNIX)
-  target_link_libraries(fwb_ipf c dl util)
+  target_link_libraries(fwb_ipf c ${CMAKE_DL_LIBS} util)
 ENDIF()
 
 target_compile_options(fwb_ipf PRIVATE ${CXX_DEFAULT_FLAGS})

--- a/src/ipfw/CMakeLists.txt
+++ b/src/ipfw/CMakeLists.txt
@@ -10,7 +10,7 @@ IF (WIN32)
 ENDIF()
 
 IF (UNIX)
-  target_link_libraries(fwb_ipfw c dl util)
+  target_link_libraries(fwb_ipfw c ${CMAKE_DL_LIBS} util)
 ENDIF()
 
 target_compile_options(fwb_ipfw PRIVATE ${CXX_DEFAULT_FLAGS})

--- a/src/ipt/CMakeLists.txt
+++ b/src/ipt/CMakeLists.txt
@@ -10,7 +10,7 @@ IF (WIN32)
 ENDIF()
 
 IF (UNIX)
-  target_link_libraries(fwb_ipt c dl util)
+  target_link_libraries(fwb_ipt c ${CMAKE_DL_LIBS} util)
 ENDIF()
 
 target_compile_options(fwb_ipt PRIVATE ${CXX_DEFAULT_FLAGS})

--- a/src/junosacl/CMakeLists.txt
+++ b/src/junosacl/CMakeLists.txt
@@ -11,7 +11,7 @@ IF (WIN32)
 ENDIF()
 
 IF (UNIX)
-  target_link_libraries(fwb_junosacl c dl util)
+  target_link_libraries(fwb_junosacl c ${CMAKE_DL_LIBS} util)
 ENDIF()
 
 target_compile_options(fwb_junosacl PRIVATE ${CXX_DEFAULT_FLAGS})

--- a/src/nxosacl/CMakeLists.txt
+++ b/src/nxosacl/CMakeLists.txt
@@ -10,7 +10,7 @@ IF (WIN32)
 ENDIF()
 
 IF (UNIX)
-  target_link_libraries(fwb_nxosacl c dl util)
+  target_link_libraries(fwb_nxosacl c ${CMAKE_DL_LIBS} util)
 ENDIF()
 
 target_compile_options(fwb_nxosacl PRIVATE ${CXX_DEFAULT_FLAGS})

--- a/src/pf/CMakeLists.txt
+++ b/src/pf/CMakeLists.txt
@@ -10,7 +10,7 @@ IF (WIN32)
 ENDIF()
 
 IF (UNIX)
-  target_link_libraries(fwb_pf c dl util)
+  target_link_libraries(fwb_pf c ${CMAKE_DL_LIBS} util)
 ENDIF()
 
 target_compile_options(fwb_pf PRIVATE ${CXX_DEFAULT_FLAGS})

--- a/src/pix/CMakeLists.txt
+++ b/src/pix/CMakeLists.txt
@@ -10,7 +10,7 @@ IF (WIN32)
 ENDIF()
 
 IF (UNIX)
-  target_link_libraries(fwb_pix c dl util)
+  target_link_libraries(fwb_pix c ${CMAKE_DL_LIBS} util)
 ENDIF()
 
 target_compile_options(fwb_pix PRIVATE ${CXX_DEFAULT_FLAGS})

--- a/src/procurve_acl/CMakeLists.txt
+++ b/src/procurve_acl/CMakeLists.txt
@@ -11,7 +11,7 @@ IF (WIN32)
 ENDIF()
 
 IF (UNIX)
-  target_link_libraries(fwb_procurve_acl c dl util)
+  target_link_libraries(fwb_procurve_acl c ${CMAKE_DL_LIBS} util)
 ENDIF()
 
 target_compile_options(fwb_procurve_acl PRIVATE ${CXX_DEFAULT_FLAGS})


### PR DESCRIPTION
libdl is not always a standalone library, some systems like OpenBSD have it [integrated in libc](https://www.openbsd.org/faq/ports/guide.html#PortsPolicy).

This PR lets [CMAKE_DL_LIBS](https://cmake.org/cmake/help/latest/variable/CMAKE_DL_LIBS.html) decide if '-ldl' is needed as a linker flag, and as such does not hardcode 'dl' in target_link_libraries().