### PR TITLE
Use CMAKE_INSTALL_MANDIR

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -39,6 +39,6 @@ if(UNIX AND NOT APPLE)
             ${CMAKE_BINARY_DIR}/fwb_ipt.1.gz
             ${CMAKE_BINARY_DIR}/fwb_pf.1.gz
             ${CMAKE_BINARY_DIR}/fwb_pix.1.gz
-            DESTINATION ${CMAKE_INSTALL_DATADIR}/man/man1)
+            DESTINATION ${CMAKE_INSTALL_MANDIR}/man1)
 endif(UNIX AND NOT APPLE)
 


### PR DESCRIPTION
Install manpages in the system's manpage folder instead of using [CMAKE_INSTALL_DATADIR](https://cmake.org/cmake/help/latest/command/install.html#installing-files). This allows to respect manpage hierarchy on any OSes where there are provided.

`GNUInstallDirs` being already included in the main CMakeLists.txt, it's a simple one line diff.