### PR TITLE
Avoid creating PuTTY session "fwb_session_with_keepalive" on runtime.

### DIFF
--- a/src/libgui/FWBSettings.cpp
+++ b/src/libgui/FWBSettings.cpp
@@ -168,10 +168,10 @@ FWBSettings::FWBSettings(bool testData) :
     uuid_settings = new QSettings(QSettings::IniFormat, QSettings::UserScope,
                                   OrganizationName, ApplicationName);
 #ifdef _WIN32
-    ssh_timeout_setings_object = new QSettings(QSettings::UserScope,
+    ssh_timeout_settings_object = new QSettings(QSettings::UserScope,
                                                  "SimonTatham", "PuTTY");
 #else
-    ssh_timeout_setings_object = this;
+    ssh_timeout_settings_object = this;
 #endif
 }
 
@@ -179,7 +179,7 @@ FWBSettings::~FWBSettings()
 {
     delete uuid_settings;
 #ifdef _WIN32
-    delete ssh_timeout_setings_object;
+    delete ssh_timeout_settings_object;
 #endif
 }
 
@@ -883,21 +883,21 @@ void FWBSettings::setDiffPath(const QString &path)
 // and keeps it as part of the session, stored in registry. Using
 // separate QSettings object on windows that controls putty session
 // "fwb_session_with_keepalive". On all other platforms
-// ssh_timeout_setings_object == this
+// ssh_timeout_settings_object == this
 
 bool FWBSettings::haveSSHTimeout()
 {
-    return ssh_timeout_setings_object->contains(SSHTimeout);
+    return ssh_timeout_settings_object->contains(SSHTimeout);
 }
 
 int FWBSettings::getSSHTimeout()
 {
-    return ssh_timeout_setings_object->value(SSHTimeout).toInt();
+    return ssh_timeout_settings_object->value(SSHTimeout).toInt();
 }
 
 void FWBSettings::setSSHTimeout(int value_sec)
 {
-    ssh_timeout_setings_object->setValue(SSHTimeout, value_sec);
+    ssh_timeout_settings_object->setValue(SSHTimeout, value_sec);
 }
 
 

--- a/src/libgui/FWBSettings.cpp
+++ b/src/libgui/FWBSettings.cpp
@@ -403,10 +403,11 @@ void FWBSettings::init(bool force_first_time_run)
 #ifndef _WIN32
     if (getSSHPath().isEmpty()) setSSHPath("ssh");
     if (getSCPPath().isEmpty()) setSCPPath("scp");
-#endif
-    // default timeout is 30 sec (default value of ServerAliveCountMax is 3)
-    // do this for both Linux and windows !
+
+    // Default timeout is 30 sec (default value of ServerAliveCountMax is 3).
+    // Do this for Linux only, Windows-installer creates the value always!
     if (!haveSSHTimeout()) setSSHTimeout(10);
+#endif
 
     // Note: hasKey calls QSettings::contains using path given as
     // argument, prepended with SETTINGS_PATH_PREFIX

--- a/src/libgui/FWBSettings.h
+++ b/src/libgui/FWBSettings.h
@@ -60,13 +60,13 @@ class FWBSettings : public QSettings
 
  private:
     QSettings *uuid_settings;
-    QSettings *ssh_timeout_setings_object;
+    QSettings *ssh_timeout_settings_object;
     bool first_run;
-    
+
     QString getLabelColorStr(enum LabelColors c);
     QString getDiffColorStr(enum LabelColors c);
 
-    
+
  public:
 
     FWBSettings(bool testData = false);
@@ -79,7 +79,7 @@ class FWBSettings : public QSettings
     void save();
 
     bool isFirstRun() { return first_run; }
-    
+
     QString getWDir();
     void    setWDir(const QString &wd);
 
@@ -138,7 +138,7 @@ class FWBSettings : public QSettings
     void    setDontSaveStdLib( bool f);
 
     bool hasKey(const QString &attribute);
-    
+
     QString getStr(const QString &attribute);
     void    setStr(const QString &attribute, const QString &val);
 
@@ -187,10 +187,10 @@ class FWBSettings : public QSettings
 
     bool isReminderAboutStandardLibSuppressed();
     void suppressReminderAboutStandardLib(bool f);
-    
+
     bool isReminderAboutDataDirSuppressed();
     void suppressReminderAboutDataDir(bool f);
-    
+
     enum IconSize getIconsInRulesSize();
     void setIconsInRulesSize(enum IconSize size);
 
@@ -220,10 +220,10 @@ class FWBSettings : public QSettings
 
     uint getTimeOfLastUpdateAvailableWarning();
     void setTimeOfLastUpdateAvailableWarning(uint v);
-    
+
     uint getTimeOfLastAnnouncement(const QString &announcement);
     void setTimeOfLastAnnouncement(const QString &announcement, uint v);
-    
+
     QString getTargetStatus(const QString &platform, const QString &default_stat);
     void setTargetStatus(const QString &plaform, const QString &status);
 
@@ -274,7 +274,7 @@ class FWBSettings : public QSettings
 
     bool getIconsWithText();
     void setIconsWithText(bool f);
-    
+
     int getABTestingGroup();
     void setABTestingGroup(int n);
 
@@ -288,7 +288,7 @@ class FWBSettings : public QSettings
 
     bool getDisplayUnmodifiedRules();
     void setDisplayUnmodifiedRules(bool);
-    
+
 private:
     QFont getFontByType(const char*type);
 };


### PR DESCRIPTION
Conceptually, that session is created by the Windows-installer already and creating it on runtime bloats existing PuTTY-sessions for people who don't want to use PuTTY-integration on Windows at all. It seems somewhat inconsistent to not create all of the values created by the installer on runtime as well.

There's one problem with the current approach, though: When the installer is executed as a different user than the one used to actually run FWB itself, like ADMIN vs. USER, the settings for the PuTTY-session are missing now, while they were available before. Though, that setup only worked by accident most likely, because not all values written by the installer were available. Additionally, default usage on Windows is that even with an elevated session HKCUÄ maps to the originally executing user of the installer, so everything will be fine. A lot of installers have this exact problem when writing user-specific values anyway, so it might not be such a big deal at all.