### PR TITLE
Fix compilation errors with gcc 11.2.1

### DIFF
--- a/src/libgui/ObjConflictResolutionDialog.cpp
+++ b/src/libgui/ObjConflictResolutionDialog.cpp
@@ -298,19 +298,19 @@ void ObjConflictResolutionDialog::setFlags()
 
 void ObjConflictResolutionDialog::accept()
 {
-  if (fwbdebug)
-    qDebug("ObjConflictResolutionDialog::accept(): isVisible=%d",
-	   isVisible());
-
+    if (fwbdebug) {
+      qDebug("ObjConflictResolutionDialog::accept(): isVisible=%d",
+             isVisible());
+    }
     QDialog::accept();
 }
 
 void ObjConflictResolutionDialog::reject()
 {
-  if (fwbdebug)
-    qDebug("ObjConflictResolutionDialog::reject(): isVisible=%d",
-	   isVisible());
-
+    if (fwbdebug) {
+      qDebug("ObjConflictResolutionDialog::reject(): isVisible=%d",
+	     isVisible());
+    }
     QDialog::reject();
 }
 


### PR DESCRIPTION
src/libgui/ObjConflictResolutionDialog.cpp: In member function \
‘virtual void ObjConflictResolutionDialog::accept()’:
src/libgui/ObjConflictResolutionDialog.cpp:301:3: error: this ‘if’ \
clause does not guard... [-Werror=misleading-indentation]
  301 |   if (fwbdebug)
      |   ^~
src/libgui/ObjConflictResolutionDialog.cpp:305:5: note: ...this \
statement, but the latter is misleadingly indented as if it were \
guarded by the ‘if’
  305 |     QDialog::accept();
      |     ^~~~~~~